### PR TITLE
Fix build

### DIFF
--- a/Big-Shoulders-Inline/sources/config.yml
+++ b/Big-Shoulders-Inline/sources/config.yml
@@ -1,6 +1,7 @@
     sources:
       - BigShouldersInline.glyphs
     familyName: Big Shoulders Inline
+    autohintOTF: false
     # buildOTF: False
     # buildTTF: False
     # buildWebfont: False

--- a/Big-Shoulders-Stencil/sources/config.yml
+++ b/Big-Shoulders-Stencil/sources/config.yml
@@ -1,6 +1,7 @@
     sources:
       - BigShouldersStencil.glyphs
     familyName: Big Shoulders Stencil
+    autohintOTF: false
     # buildOTF: False
     # buildTTF: False
     # buildWebfont: False

--- a/Big-Shoulders/sources/config.yml
+++ b/Big-Shoulders/sources/config.yml
@@ -1,6 +1,7 @@
     sources:
       - BigShoulders.glyphs
     familyName: Big Shoulders
+    autohintOTF: false
     # buildOTF: False
     # buildTTF: False
     # buildWebfont: False


### PR DESCRIPTION
This disables the new OTF autohinting in gftools. This is a new feature in gftools that is turned on by default, but it requires setting up the zones correctly for postscript hinting.